### PR TITLE
Remove test.util from source path

### DIFF
--- a/src/invetica/test/util.clj
+++ b/src/invetica/test/util.clj
@@ -1,7 +1,0 @@
-(ns invetica.test.util
-  (:require
-   [clojure.pprint :refer [pprint]]))
-
-(defn pprint-str
-  [x]
-  (with-out-str (pprint x)))


### PR DESCRIPTION
I'm not using `pprint-str`, and the file was in the wrong place so let's get rid of it!

Fixes #7.